### PR TITLE
feat: built-in ChordPro (chopro/chordpro) lead-sheet rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,30 @@ Volpiano files can also be rendered from the vault when using a `.volpiano`, `.v
 
 Note: Verovio imports Volpiano as regular MEI notes and produces playable MIDI. It does not currently preserve Volpiano neume grouping such as `gf` / `hgf` as grouped neumes, and line/page/column breaks such as `7` / `77` / `777` are not handled like in `music21.volpiano`.
 
+## (NEW) ChordPro Lead Sheets
+
+Verovio Music Renderer has **ChordPro integrated**: alongside engraved notation, it renders chord-and-lyric lead sheets from `chopro` (or `chordpro`) code blocks. One plugin covers both — engraved scores *and* chord sheets. (Under the hood, ChordPro carries no pitch or rhythm to engrave, so the plugin renders these blocks with a built-in lead-sheet layout rather than the Verovio engraving engine — but it's all one plugin.)
+
+````
+```chopro
+{title: Sweet Home Alabama}
+{key: D}
+
+[D]Big wheels keep on [C]turnin'
+[G]Carry me home to see my [D]kin
+```
+````
+
+Supported syntax:
+
+- **Inline chords** in square brackets, immediately before the syllable they change on: `[G]Carry`.
+- **Directives** in curly braces: `{title:}` / `{t:}`, `{subtitle:}` / `{st:}`, `{comment:}` / `{c:}`, and any `key: value` directive (`{key: D}`, `{capo: 2}`, `{tempo: 120}`, `{artist: …}`) renders as a metadata row.
+- **Sections**: `{start_of_chorus}` / `{soc}` … `{end_of_chorus}` / `{eoc}` (also verse `{sov}`, bridge `{sob}`, tab `{sot}`), rendered as labelled groups.
+
+**Accessibility.** The ChordPro renderer is built screen-reader-first: the DOM preserves chord-then-syllable order, so a screen reader reads a line the way a musician would — *"G chord, Carry me home to see my, D chord, kin"*. Chords carry an `aria-label` (so `Am` is announced as "Am chord", not the word "am"), the title renders as a heading, choruses and verses are labelled groups, and chords are set apart by weight and position — never by colour alone (WCAG 1.4.1).
+
+**Note:** `chopro` and `chordpro` are also the code-block languages used by the standalone *ChordPro Viewer* plugin. Only one plugin can own a code-block language, so **disable ChordPro Viewer** if you want this plugin to handle ChordPro rendering.
+
 ## Plaine & Easie Editor
 You can open a Plaine & Easie editor from the Obsidian Command Palette with the command "Insert Plaine & Easie music codeblock". It provides a notation-oriented input modal with note values, rests, clefs, key signatures, a small piano keyboard, live Verovio preview, and inserts the result as a compact PAE code block.
 
@@ -369,6 +393,7 @@ This plugin respects your privacy:
 - [Verovio PAE Editor](https://www.verovio.org/pae-editor.html) – many functions for quick and dirty PAE insertion were adapted from this editor
 - [mei-friend](https://github.com/mei-friend/mei-friend) – the side panel editing functions were taken from the mei-friend editor
 - [lz-midi](https://github.com/AAlittleWhite/lz-midi)
+- [ChordPro Viewer](https://github.com/jheddings/obsidian-chopro) by [jheddings](https://github.com/jheddings) – the ChordPro (`chopro` / `chordpro`) code-block convention the integrated lead-sheet renderer follows
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ This plugin respects your privacy:
 - [Verovio PAE Editor](https://www.verovio.org/pae-editor.html) – many functions for quick and dirty PAE insertion were adapted from this editor
 - [mei-friend](https://github.com/mei-friend/mei-friend) – the side panel editing functions were taken from the mei-friend editor
 - [lz-midi](https://github.com/AAlittleWhite/lz-midi)
-- [ChordPro Viewer](https://github.com/jheddings/obsidian-chopro) by [jheddings](https://github.com/jheddings) – the ChordPro (`chopro` / `chordpro`) code-block convention the integrated lead-sheet renderer follows
+- [ChordPro Viewer](https://github.com/jheddings/obsidian-chopro) by [jheddings](https://github.com/jheddings) – the inspiration for ChordPro (`chopro` / `chordpro`) support here; seeing this plugin is what sparked the feature, which is an independent reimplementation of the idea in our own way
 
 ## FAQ
 

--- a/src/chordpro/chordProBlock.ts
+++ b/src/chordpro/chordProBlock.ts
@@ -1,0 +1,215 @@
+// Lightweight ChordPro renderer for `chopro` / `chordpro` code blocks.
+//
+// This is intentionally independent of Verovio: ChordPro carries no pitch or
+// rhythm, so there is nothing to engrave — it is chord names positioned over
+// lyric text. The renderer is built screen-reader-first:
+//   - DOM order is chord-then-syllable, so a screen reader reads a line the way
+//     a musician would ("G, Carry me, D, home"), while CSS stacks the chord
+//     above the syllable visually.
+//   - Chords carry an aria-label ("G chord") so tokens like "Am" are not read
+//     as the word "am".
+//   - The title renders as a heading and choruses/verses as labelled groups,
+//     and chords are distinguished by weight + position, never colour alone.
+
+interface ChordSegment {
+  chord?: string;
+  text: string;
+}
+
+type ChordProNode =
+  | { type: 'title'; value: string }
+  | { type: 'subtitle'; value: string }
+  | { type: 'meta'; label: string; value: string }
+  | { type: 'comment'; value: string }
+  | { type: 'section-start'; kind: SectionKind; label: string }
+  | { type: 'section-end' }
+  | { type: 'line'; segments: ChordSegment[] }
+  | { type: 'empty' };
+
+type SectionKind = 'chorus' | 'verse' | 'bridge' | 'tab';
+
+const DIRECTIVE_RE = /^\s*\{\s*([^:}]+?)\s*(?::\s*([\s\S]*?))?\s*\}\s*$/;
+const INLINE_CHORD_RE = /\[([^\]]*)\]/g;
+
+const SECTION_LABELS: Record<SectionKind, string> = {
+  chorus: 'Chorus',
+  verse: 'Verse',
+  bridge: 'Bridge',
+  tab: 'Tablature',
+};
+
+/** Entry point registered as the `chopro` / `chordpro` code-block processor. */
+export function renderChordProBlock(source: string, el: HTMLElement) {
+  const nodes = parseChordPro(source);
+  renderNodes(nodes, el);
+}
+
+export function parseChordPro(source: string): ChordProNode[] {
+  const nodes: ChordProNode[] = [];
+
+  for (const rawLine of source.replace(/\r\n?/g, '\n').split('\n')) {
+    const line = rawLine.trimEnd();
+    if (line.trim() === '') {
+      nodes.push({ type: 'empty' });
+      continue;
+    }
+
+    const directive = line.match(DIRECTIVE_RE);
+    if (directive) {
+      const node = parseDirective(directive[1].trim().toLowerCase(), (directive[2] ?? '').trim());
+      if (node) nodes.push(node);
+      continue;
+    }
+
+    nodes.push({ type: 'line', segments: parseChordLine(rawLine) });
+  }
+
+  return nodes;
+}
+
+function parseDirective(name: string, value: string): ChordProNode | null {
+  switch (name) {
+    case 'title':
+    case 't':
+      return { type: 'title', value };
+    case 'subtitle':
+    case 'st':
+      return { type: 'subtitle', value };
+    case 'comment':
+    case 'c':
+    case 'comment_italic':
+    case 'ci':
+      return { type: 'comment', value };
+    case 'start_of_chorus':
+    case 'soc':
+      return { type: 'section-start', kind: 'chorus', label: value || SECTION_LABELS.chorus };
+    case 'start_of_verse':
+    case 'sov':
+      return { type: 'section-start', kind: 'verse', label: value || SECTION_LABELS.verse };
+    case 'start_of_bridge':
+    case 'sob':
+      return { type: 'section-start', kind: 'bridge', label: value || SECTION_LABELS.bridge };
+    case 'start_of_tab':
+    case 'sot':
+      return { type: 'section-start', kind: 'tab', label: value || SECTION_LABELS.tab };
+    case 'end_of_chorus':
+    case 'eoc':
+    case 'end_of_verse':
+    case 'eov':
+    case 'end_of_bridge':
+    case 'eob':
+    case 'end_of_tab':
+    case 'eot':
+      return { type: 'section-end' };
+    default:
+      // Remaining `key: value` directives (key, capo, tempo, artist, album…)
+      // become readable metadata rows. Bare directives with no value are
+      // ignored rather than rendered as empty rows.
+      if (!value) return null;
+      return { type: 'meta', label: titleCase(name.replace(/_/g, ' ')), value };
+  }
+}
+
+/** Splits a lyric line into chord/text segments, preserving source order. */
+function parseChordLine(line: string): ChordSegment[] {
+  const segments: ChordSegment[] = [];
+  let lastIndex = 0;
+  let pendingChord: string | undefined;
+
+  INLINE_CHORD_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = INLINE_CHORD_RE.exec(line)) !== null) {
+    const text = line.slice(lastIndex, match.index);
+    if (text || pendingChord !== undefined) {
+      segments.push({ chord: pendingChord, text });
+    }
+    pendingChord = match[1];
+    lastIndex = INLINE_CHORD_RE.lastIndex;
+  }
+
+  const tail = line.slice(lastIndex);
+  if (tail || pendingChord !== undefined || segments.length === 0) {
+    segments.push({ chord: pendingChord, text: tail });
+  }
+
+  return segments;
+}
+
+function renderNodes(nodes: ChordProNode[], el: HTMLElement) {
+  const title = nodes.find((n): n is Extract<ChordProNode, { type: 'title' }> => n.type === 'title')?.value;
+
+  const sheet = el.createDiv('chopro-sheet');
+  sheet.setAttribute('role', 'group');
+  sheet.setAttribute('aria-label', title ? `Chord sheet: ${title}` : 'Chord sheet');
+
+  // Lines inside a {start_of_*}…{end_of_*} block are appended to a labelled
+  // group so screen-reader users can identify choruses/verses.
+  let target: HTMLElement = sheet;
+
+  for (const node of nodes) {
+    switch (node.type) {
+      case 'title':
+        sheet.createEl('h4', { cls: 'chopro-title', text: node.value });
+        break;
+      case 'subtitle':
+        sheet.createEl('div', { cls: 'chopro-subtitle', text: node.value });
+        break;
+      case 'meta':
+        renderMeta(sheet, node.label, node.value);
+        break;
+      case 'comment':
+        target.createEl('div', { cls: 'chopro-comment', text: node.value });
+        break;
+      case 'section-start': {
+        const section = sheet.createDiv(`chopro-section chopro-${node.kind}`);
+        section.setAttribute('role', 'group');
+        section.setAttribute('aria-label', node.label);
+        section.createEl('div', { cls: 'chopro-section-label', text: node.label });
+        target = section;
+        break;
+      }
+      case 'section-end':
+        target = sheet;
+        break;
+      case 'line':
+        renderLine(target, node.segments);
+        break;
+      case 'empty':
+        target.createDiv('chopro-spacer');
+        break;
+    }
+  }
+}
+
+function renderMeta(sheet: HTMLElement, label: string, value: string) {
+  const row = sheet.createDiv('chopro-meta');
+  row.createEl('span', { cls: 'chopro-meta-label', text: `${label}: ` });
+  row.createEl('span', { cls: 'chopro-meta-value', text: value });
+}
+
+function renderLine(parent: HTMLElement, segments: ChordSegment[]) {
+  const line = parent.createDiv('chopro-line');
+  const hasChords = segments.some((s) => s.chord !== undefined);
+  if (!hasChords) line.addClass('chopro-line-plain');
+
+  for (const segment of segments) {
+    const seg = line.createSpan('chopro-seg');
+
+    if (segment.chord !== undefined) {
+      const chordText = segment.chord.trim();
+      const chord = seg.createSpan('chopro-chord');
+      // Non-empty chords are read as "G chord"; an empty [] is a spacer only.
+      chord.setText(chordText || ' ');
+      if (chordText) chord.setAttribute('aria-label', `${chordText} chord`);
+      else chord.setAttribute('aria-hidden', 'true');
+    }
+
+    const lyric = seg.createSpan('chopro-lyric');
+    // Keep the syllable box from collapsing when a chord has no trailing text.
+    lyric.setText(segment.text === '' ? ' ' : segment.text);
+  }
+}
+
+function titleCase(value: string): string {
+  return value.replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { MusicEditorView, VIEW_TYPE_MUSIC_EDITOR } from './editor/musicEditorVie
 import { VerovioModal } from './pae/paeEditorModal';
 import parseVerovioSource, { VerovioFormat } from './verovio/parseVerovioSource';
 import { convertInlineCodeToMEI } from './verovio/verovioImport';
+import { renderChordProBlock } from './chordpro/chordProBlock';
 
 interface FencedSelection {
   body: string;
@@ -41,6 +42,13 @@ export default class VerovioMusicRenderer extends Plugin {
         processVerovioCodeBlocks.call(this, source, el, ctx);
       }
     );
+
+    // ChordPro lead sheets (chords + lyrics). Independent of Verovio — see
+    // chordProBlock.ts. Disable the standalone ChordPro Viewer plugin to avoid
+    // both claiming the same code-block language.
+    for (const lang of ['chopro', 'chordpro']) {
+      this.registerMarkdownCodeBlockProcessor(lang, (source, el) => renderChordProBlock(source, el));
+    }
 
     this.registerView(
       VIEW_TYPE_MUSIC_EDITOR,

--- a/styles.css
+++ b/styles.css
@@ -780,3 +780,95 @@
     margin: 0;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   ChordPro lead sheets (`chopro` / `chordpro` code blocks)
+   Screen-reader-first: DOM order is chord-then-syllable; the column layout
+   below only moves the chord visually above its syllable. Chords are set apart
+   by weight + position (not colour alone) so meaning survives without colour.
+   --------------------------------------------------------------------------- */
+.chopro-sheet {
+    font-family: var(--font-text, inherit);
+    line-height: 1.35;
+    padding: 0.25em 0;
+}
+
+.chopro-title {
+    margin: 0 0 0.1em 0;
+    font-size: 1.3em;
+    font-weight: 700;
+}
+
+.chopro-subtitle {
+    margin: 0 0 0.35em 0;
+    font-style: italic;
+    color: var(--text-muted);
+}
+
+.chopro-meta {
+    font-size: 0.9em;
+    color: var(--text-muted);
+}
+
+.chopro-meta-label {
+    font-weight: 600;
+}
+
+.chopro-comment {
+    margin: 0.35em 0;
+    font-style: italic;
+    color: var(--text-muted);
+}
+
+/* Each syllable is a column: chord on top, lyric below, so chords sit directly
+   over the syllable they change on while the DOM keeps chord-then-lyric order. */
+.chopro-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    margin: 0.15em 0;
+}
+
+.chopro-line-plain {
+    /* No chords on this line: render as an ordinary lyric line. */
+    display: block;
+}
+
+.chopro-seg {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}
+
+.chopro-chord {
+    font-weight: 700;
+    font-size: 0.85em;
+    line-height: 1.1;
+    /* AA-contrast accent; falls back to the theme's accent text colour. */
+    color: var(--text-accent, #2563eb);
+    white-space: pre;
+}
+
+.chopro-lyric {
+    white-space: pre-wrap;
+}
+
+/* Labelled chorus / verse / bridge groups. */
+.chopro-section {
+    margin: 0.4em 0;
+    padding: 0.1em 0 0.1em 0.7em;
+    border-left: 3px solid var(--interactive-accent, #2563eb);
+}
+
+.chopro-section-label {
+    font-size: 0.78em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    margin-bottom: 0.1em;
+}
+
+.chopro-spacer {
+    height: 0.7em;
+}


### PR DESCRIPTION
## Summary

Adds built-in **ChordPro lead-sheet rendering** to the plugin — chord-and-lyric sheets from `chopro` / `chordpro` code blocks, alongside the existing engraved notation. Two commits:

1. **Feature** — a self-contained renderer (`src/chordpro/chordProBlock.ts`, **no dependencies**) registered as `chopro`/`chordpro` code-block processors in `main.ts`, plus lead-sheet styling in `styles.css`. It renders independently of the Verovio engraving engine (ChordPro carries no pitch/rhythm to engrave).
2. **Docs** — a `(NEW) ChordPro Lead Sheets` README section (syntax + accessibility), and a credit under *Additionally Used (With Many Thanks)*.

## What it renders

````
```chopro
{title: Sweet Home Alabama}
{key: D}

[D]Big wheels keep on [C]turnin'
[G]Carry me home to see my [D]kin
```
````

Supports inline `[chords]`, directives (`{title:}`, `{key:}`, `{comment:}`, arbitrary `key: value`), and labelled `{start_of_chorus}` / verse / bridge / tab sections.

## Accessibility

Screen-reader-first: DOM order is chord-then-syllable (a reader hears *"G chord, Carry me home to see my, D chord, kin"*), chords carry an `aria-label` so `Am` isn't read as the word "am", the title is a heading, choruses/verses are labelled groups, and chords are set apart by weight + position — never colour alone (WCAG 1.4.1).

## Credit

The renderer is an **independent reimplementation** — seeing **[ChordPro Viewer](https://github.com/jheddings/obsidian-chopro) by jheddings** is what sparked the idea, and it's built in this plugin's own way (no code shared). Because both claim the `chopro`/`chordpro` code-block languages, the README notes you'd disable one or the other. Credited in the README as a shout-out.

## Notes

- **Contributed by jdhori.**
- Type-checks cleanly against the base (adds **0** new `tsc` errors).
- Excludes version bumps and the built `main.js` bundle — those are the maintainer's call to rebuild/release.
